### PR TITLE
[telnet] 修复未开启 POSIX 的情况下，关闭 Telnet 无法真正切换到 UART console 的问题

### DIFF
--- a/telnet/telnet.c
+++ b/telnet/telnet.c
@@ -228,10 +228,11 @@ static void client_close(struct telnet_session* telnet)
 #if defined(RT_USING_POSIX)
     ioctl(libc_stdio_get_console(), F_SETFL, (void *) dev_old_flag);
     libc_stdio_set_console(RT_CONSOLE_DEVICE_NAME, O_RDWR);
-    rt_sem_release(telnet->read_notice);
 #else
     finsh_set_device(RT_CONSOLE_DEVICE_NAME);
 #endif /* RT_USING_POSIX */
+
+    rt_sem_release(telnet->read_notice);
 
     /* close connection */
     closesocket(telnet->client_fd);


### PR DESCRIPTION
[telnet] 修复未开启 POSIX 的情况下，关闭 Telnet 无法真正切换到 UART console 的问题

Signed-off-by: MurphyZhao <d2014zjt@163.com>