### PR TITLE
将rtc驱动框架中涉及到NTP的部分放入ntp文件内

### DIFF
--- a/ntp/README.md
+++ b/ntp/README.md
@@ -1,16 +1,28 @@
 # NTP：网络时间协议
 
-## 1、介绍
+## 1 介绍
 
 [NTP](https://baike.baidu.com/item/NTP) 是网络时间协议(Network Time Protocol)，它是用来同步网络中各个计算机时间的协议。
 
 在 RT-Thread 上实现了 NTP 客户端，连接上网络后，可以获取当前 UTC 时间，并更新至 RTC 中。
 
-## 2、使用
+## 2 使用
 
-首先打开 meunconfig ，配置并开启 netutils 软件包。在配置选项中，默认提供了 3 个 NTP 服务器，保证了 NTP 功能的可靠性。
+首先打开 meunconfig ，配置并开启 netutils 软件包。
 
-### 2.1 获取 UTC 时间
+### 2.1 启用 NTP 时间自动同步
+
+如果 RT-Thread 已接入互联网，可启用 NTP 时间自动同步功能，定期同步本地时间。
+
+在 menuconfig 中启用 `RTC_SYNC_USING_NTP` 配置。启用该功能后，会自动开启 [netutils package](https://github.com/RT-Thread-packages/netutils) 的 NTP 功能。同时务必确保 RT-Thread 网络访问正常。
+
+启用该配置后，还有三个配置是用户可选配置：
+
+- 在配置选项中，默认提供了 3 个 NTP 服务器，保证了 NTP 功能的可靠性。
+- `RTC_NTP_FIRST_SYNC_DELAY`: 首次执行 NTP 时间同步的延时。延时的目的在于，给网络连接预留一定的时间，尽量提高第一次执行 NTP 时间同步时的成功率。默认时间为 30S；
+- `RTC_NTP_SYNC_PERIOD`: NTP 自动同步周期，单位为秒，默认一小时（即 3600S）同步一次。
+
+### 2.2 获取 UTC 时间
 
 [UTC 时间](https://baike.baidu.com/item/%E5%8D%8F%E8%B0%83%E4%B8%96%E7%95%8C%E6%97%B6/787659?fromtitle=UTC&fromid=5899996) 又称世界统一时间、世界标准时间、国际协调时间。北京时间为 UTC+8 时间，比 UTC 时间多 8 小时，或者理解为早 8 小时。
 
@@ -39,7 +51,7 @@ void main(void)
 }
 ```
 
-### 2.2 获取本地时间
+### 2.3 获取本地时间
 
 本地时间比 UTC 时间多了时区的概念，例如：北京时间为东八区，比 UTC 时间多 8 个小时。
 
@@ -53,7 +65,7 @@ API: `time_t ntp_get_local_time(void)`
 
 该 API 使用方法与 `ntp_get_time()` 类似
 
-### 2.3 同步本地时间至 RTC
+### 2.4 同步本地时间至 RTC
 
 如果开启 RTC 设备，还可以使用下面的命令及 API 同步 NTP 的本地时间至 RTC 设备。
 
@@ -72,7 +84,7 @@ API: `time_t ntp_sync_to_rtc(void)`
 |:-----                                  |:----|
 |return                                  |`>0`: 当前本地时间，`=0`：同步时间失败|
 
-## 3、注意事项
+## 3 注意事项
 
 - 1、NTP API 方法执行时会占用较多的线程堆栈，使用时保证堆栈空间充足（≥1.5K）；
 - 2、NTP API 方法 **不支持可重入** ，并发使用时，请注意加锁。

--- a/ntp/ntp.c
+++ b/ntp/ntp.c
@@ -59,11 +59,8 @@ extern int closesocket(int s);
 #include <rtdbg.h>
 
 #if RT_VER_NUM <= 0x40003
-#ifdef NETUTILS_NTP_TIMEZONE
-#define NTP_TIMEZONE                   NETUTILS_NTP_TIMEZONE
-#endif
-#ifndef NTP_TIMEZONE
-#define NTP_TIMEZONE                   8
+#ifndef NETUTILS_NTP_TIMEZONE
+#define NETUTILS_NTP_TIMEZONE                   8
 #endif
 #endif
 
@@ -342,7 +339,7 @@ __exit:
  *
  * @param host_name NTP server host name, NULL: will using default host name
  *
- * @return >0: success, current local time, offset timezone by NTP_TIMEZONE
+ * @return >0: success, current local time, offset timezone by NETUTILS_NTP_TIMEZONE
  *         =0: get failed
  */
 time_t ntp_get_local_time(const char *host_name)
@@ -352,7 +349,7 @@ time_t ntp_get_local_time(const char *host_name)
     if (cur_time)
     {
         /* add the timezone offset for set_time/set_date */
-        cur_time += NTP_TIMEZONE * 3600;
+        cur_time += NETUTILS_NTP_TIMEZONE * 3600;
     }
 
     return cur_time;

--- a/ntp/ntp.c
+++ b/ntp/ntp.c
@@ -424,7 +424,7 @@ static int rt_rtc_ntp_sync_init(void)
         return 0;
     }
 
-    thread = rt_thread_create("ntp_sync", ntp_sync_thread_enrty, RT_NULL, 1300, 26, 2);
+    thread = rt_thread_create("ntp_sync", ntp_sync_thread_enrty, RT_NULL, 1300, RT_THREAD_PRIORITY_MAX - 2, 20);
     if (thread)
     {
         rt_thread_startup(thread);

--- a/ntp/ntp.c
+++ b/ntp/ntp.c
@@ -385,9 +385,9 @@ time_t ntp_sync_to_rtc(const char *host_name)
 #else
         rt_device_control(rt_device_find("rtc"), RT_DEVICE_CTRL_RTC_SET_TIME, &cur_time);
 #endif /*RT_VER_NUM <= 0x40003*/
-        rt_kprintf("Get local time from NTP server: %s", ctime((const time_t *) &cur_time));
+        LOG_I("Get local time from NTP server: %s", ctime((const time_t *) &cur_time));
 #else
-        rt_kprintf("The system time update failed. Please enable RT_USING_RTC.\n");
+        LOG_E("The system time update failed. Please enable RT_USING_RTC.\n");
         cur_time = 0;
 #endif /* RT_USING_RTC */
     }
@@ -427,7 +427,7 @@ static int rt_rtc_ntp_sync_init(void)
         return 0;
     }
 
-    thread = rt_thread_create("ntp_sync", ntp_sync_thread_enrty, RT_NULL, 2048, 26, 2);
+    thread = rt_thread_create("ntp_sync", ntp_sync_thread_enrty, RT_NULL, 1300, 26, 2);
     if (thread)
     {
         rt_thread_startup(thread);

--- a/ntp/ntp.h
+++ b/ntp/ntp.h
@@ -21,6 +21,7 @@
  * Date           Author       Notes
  * 2018-02-10     armink       the first version
  * 2020-07-21     Chenxuan     C++ support
+ * 2021-05-09     Meco Man     remove timezone function
  */
 
 #ifndef __NTP_H__
@@ -44,6 +45,7 @@ extern "C" {
  */
 time_t ntp_get_time(const char *host_name);
 
+#if RT_VER_NUM <= 0x40003
 /**
  * Get the local time from NTP server
  *
@@ -53,6 +55,7 @@ time_t ntp_get_time(const char *host_name);
  *         =0: get failed
  */
 time_t ntp_get_local_time(const char *host_name);
+#endif
 
 /**
  * Sync current local time to RTC by NTP

--- a/tcpdump/tcpdump.c
+++ b/tcpdump/tcpdump.c
@@ -116,10 +116,10 @@ do{                                                             \
 
 struct tcpdump_buf
 {
-    rt_uint16_t tot_len; 
-    rt_tick_t tick; 
-    void *buf; 
-}; 
+    rt_uint16_t tot_len;
+    rt_tick_t tick;
+    void *buf;
+};
 
 struct rt_pcap_file_header
 {
@@ -210,16 +210,16 @@ static err_t _netif_linkoutput(struct netif *netif, struct pbuf *p)
     RT_ASSERT(tbuf != RT_NULL);
     RT_ASSERT(netif != RT_NULL);
 
-    tbuf->tick = rt_tick_get(); 
-    tbuf->buf = ((rt_uint8_t *)tbuf) + sizeof(struct tcpdump_buf); 
-    tbuf->tot_len = p->tot_len; 
+    tbuf->tick = rt_tick_get();
+    tbuf->buf = ((rt_uint8_t *)tbuf) + sizeof(struct tcpdump_buf);
+    tbuf->tot_len = p->tot_len;
     pbuf_copy_partial(p, tbuf->buf, p->tot_len, 0);
 
     if (p != RT_NULL)
     {
         if (rt_mb_send(tcpdump_mb, (rt_uint32_t)tbuf) != RT_EOK)
         {
-            rt_free(tbuf); 
+            rt_free(tbuf);
         }
     }
     return link_output(netif, p);
@@ -234,16 +234,16 @@ static err_t _netif_input(struct pbuf *p, struct netif *inp)
     RT_ASSERT(tbuf != RT_NULL);
     RT_ASSERT(netif != RT_NULL);
 
-    tbuf->tick = rt_tick_get(); 
-    tbuf->buf = ((rt_uint8_t *)tbuf) + sizeof(struct tcpdump_buf); 
-    tbuf->tot_len = p->tot_len; 
+    tbuf->tick = rt_tick_get();
+    tbuf->buf = ((rt_uint8_t *)tbuf) + sizeof(struct tcpdump_buf);
+    tbuf->tot_len = p->tot_len;
     pbuf_copy_partial(p, tbuf->buf, p->tot_len, 0);
 
     if (p != RT_NULL)
     {
         if (rt_mb_send(tcpdump_mb, (rt_uint32_t)tbuf) != RT_EOK)
         {
-            rt_free(tbuf); 
+            rt_free(tbuf);
         }
     }
     return input(p, inp);
@@ -299,7 +299,7 @@ static rt_err_t rt_tcpdump_pcap_file_save(const void *buf, int len)
 /* write ip mess and print */
 static void rt_tcpdump_ip_mess_write(struct tcpdump_buf *p)
 {
-    struct tcpdump_buf *tbuf = p; 
+    struct tcpdump_buf *tbuf = p;
 
     RT_ASSERT(tbuf != RT_NULL);
 
@@ -310,7 +310,7 @@ static void rt_tcpdump_ip_mess_write(struct tcpdump_buf *p)
     /* write ip mess */
     if (tcpdump_write != RT_NULL)
     {
-        // rt_kprintf("tbuf->tot_len = %d\n", tbuf->tot_len); 
+        // rt_kprintf("tbuf->tot_len = %d\n", tbuf->tot_len);
         tcpdump_write(tbuf->buf, tbuf->tot_len);
     }
 }
@@ -339,17 +339,17 @@ static rt_err_t rt_tcpdump_pcap_file_init(void)
         PACP_FILE_HEADER_CREATE(&file_header);
         res = tcpdump_write(&file_header, sizeof(file_header));
 
-        /* Positioning at time zero */ 
-        char pacp_zero[] = 
+        /* Positioning at time zero */
+        char pacp_zero[] =
         {
-            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 
-            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 
-            0x08, 0x00, 
-            ' ', ' ', 'R', 'T', 'T', 'H', 'R', 'E', 'A', 'D', ' ', 'Z', 'E', 'R', 'O' 
-        }; 
-        PACP_ZERO_PKTHDR_CREATE(&pkthdr, sizeof(pacp_zero)); 
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00,
+            0x08, 0x00,
+            ' ', ' ', 'R', 'T', 'T', 'H', 'R', 'E', 'A', 'D', ' ', 'Z', 'E', 'R', 'O'
+        };
+        PACP_ZERO_PKTHDR_CREATE(&pkthdr, sizeof(pacp_zero));
         tcpdump_write(&pkthdr, sizeof(pkthdr));
-        tcpdump_write(pacp_zero, sizeof(pacp_zero)); 
+        tcpdump_write(pacp_zero, sizeof(pacp_zero));
     }
 
 #ifdef  PKG_NETUTILS_TCPDUMP_PRINT
@@ -365,7 +365,7 @@ static rt_err_t rt_tcpdump_pcap_file_init(void)
 static void rt_tcpdump_thread_entry(void *param)
 {
     // struct pbuf *pbuf = RT_NULL;
-    struct tcpdump_buf *tbuf = RT_NULL; 
+    struct tcpdump_buf *tbuf = RT_NULL;
     struct rt_pcap_pkthdr pkthdr;
     rt_uint32_t mbval;
 
@@ -397,7 +397,7 @@ static void rt_tcpdump_thread_entry(void *param)
             dbg_log(DBG_INFO, "tcpdump stop and tcpdump thread exit!\n");
             close(fd);
             fd = -1;
-            
+
             if (tcpdump_pipe != RT_NULL)
                 rt_device_close((rt_device_t)tcpdump_pipe);
 
@@ -524,7 +524,7 @@ static void rt_tcpdump_deinit(void)
 {
     rt_base_t level;
     struct rt_mailbox *tcpdump_mb_tmp = RT_NULL;
-    
+
     if (netif == RT_NULL)
     {
         dbg_log(DBG_ERROR, "capture packet stopped, no repeat input required!\n");
@@ -533,7 +533,7 @@ static void rt_tcpdump_deinit(void)
 
     /* linkoutput and input deinit */
     level = rt_hw_interrupt_disable();
-    tcpdump_mb_tmp = tcpdump_mb; 
+    tcpdump_mb_tmp = tcpdump_mb;
     tcpdump_mb = RT_NULL;
     netif->linkoutput = link_output;
     netif->input = input;
@@ -541,9 +541,9 @@ static void rt_tcpdump_deinit(void)
     rt_hw_interrupt_enable(level);
     /* linkoutput and input deinit */
 
-    rt_thread_mdelay(10); 
+    rt_thread_mdelay(10);
     rt_mb_delete(tcpdump_mb_tmp);
-    tcpdump_mb_tmp = RT_NULL; 
+    tcpdump_mb_tmp = RT_NULL;
 }
 
 static void rt_tcpdump_help_info_print(void)

--- a/telnet/telnet.c
+++ b/telnet/telnet.c
@@ -358,7 +358,7 @@ static void telnet_thread(void* parameter)
     telnet->device.type     = RT_Device_Class_Char;
 #ifdef RT_USING_DEVICE_OPS
     telnet->device.ops = &_ops;
-#else    
+#else
     telnet->device.init     = telnet_init;
     telnet->device.open     = telnet_open;
     telnet->device.close    = telnet_close;

--- a/tftp/tftp_port.c
+++ b/tftp/tftp_port.c
@@ -80,7 +80,7 @@ struct _tftp_cmd
     int cmd;
 };
 
-static const struct _tftp_cmd _cmd_tab[] = 
+static const struct _tftp_cmd _cmd_tab[] =
 {
     {"-s", "begin tftp server", _S_MODE_CMD},
     {"-w", "client write file to server", _CW_MODE_CMD},

--- a/tftp/tftp_xfer.h
+++ b/tftp/tftp_xfer.h
@@ -28,7 +28,7 @@
 
 #define XFER_DATA_SIZE_MAX (512)
 
-union file_info 
+union file_info
 {
     uint16_t code;
     uint16_t block;


### PR DESCRIPTION
将rtc驱动框架中涉及到NTP的部分放入ntp文件内
从4.0.3之后的版本开始，时区控制交还给RTThread

STM32F407测试通过
https://github.com/RT-Thread/rt-thread/pull/4669