### PR TITLE
fix bug #56

### DIFF
--- a/telnet/telnet.c
+++ b/telnet/telnet.c
@@ -342,6 +342,7 @@ static void telnet_thread(void* parameter)
     if(setsockopt(telnet->server_fd, SOL_SOCKET, SO_KEEPALIVE, (void *)&keepalive, sizeof(keepalive)) < 0)
 	{
 		rt_kprintf("telnet:set socket keepalive failed\n");
+        return;
 	}
 
     addr.sin_family = AF_INET;

--- a/telnet/telnet.c
+++ b/telnet/telnet.c
@@ -341,7 +341,7 @@ static void telnet_thread(void* parameter)
 
     if(setsockopt(telnet->server_fd, SOL_SOCKET, SO_KEEPALIVE, (void *)&keepalive, sizeof(keepalive)) < 0)
 	{
-		rt_kprintf("telnet:set socket keepalive failed\n");
+        rt_kprintf("telnet:set socket keepalive failed\n");
         return;
 	}
 

--- a/telnet/telnet.c
+++ b/telnet/telnet.c
@@ -331,12 +331,18 @@ static void telnet_thread(void* parameter)
     socklen_t addr_size;
     rt_uint8_t recv_buf[RECV_BUF_LEN];
     rt_int32_t recv_len = 0;
+    rt_int32_t keepalive = 1;
 
     if ((telnet->server_fd = socket(AF_INET, SOCK_STREAM, 0)) == -1)
     {
         rt_kprintf("telnet: create socket failed\n");
         return;
     }
+
+    if(setsockopt(telnet->server_fd, SOL_SOCKET, SO_KEEPALIVE, (void *)&keepalive, sizeof(keepalive)) < 0)
+	{
+		rt_kprintf("telnet:set socket keepalive failed\n");
+	}
 
     addr.sin_family = AF_INET;
     addr.sin_port = htons(TELNET_PORT);


### PR DESCRIPTION
Fix bug #56 .
At the same time, modify the following parameters in the file tcp_priv.h of LWIP.
#ifndef  TCP_KEEPIDLE_DEFAULT
#define  TCP_KEEPIDLE_DEFAULT     1000UL /* Default KEEPALIVE timer in milliseconds */
#endif

#ifndef  TCP_KEEPINTVL_DEFAULT
#define  TCP_KEEPINTVL_DEFAULT    500UL  /* Default Time between KEEPALIVE probes in milliseconds */
#endif

#ifndef  TCP_KEEPCNT_DEFAULT
#define  TCP_KEEPCNT_DEFAULT      3U       /* Default Counter for KEEPALIVE probes */
#endif