### PR TITLE
[ntp] 使用localtime_r代替localtime

### DIFF
--- a/ntp/ntp.c
+++ b/ntp/ntp.c
@@ -376,9 +376,10 @@ time_t ntp_sync_to_rtc(const char *host_name)
 #ifdef RT_USING_RTC
 #if RT_VER_NUM <= 0x40003
         struct tm *cur_tm;
-        cur_tm = localtime(&cur_time);
+        struct tm cur_tm_t;
+        cur_tm = &cur_tm_t;
+        localtime_r(&cur_time, cur_tm);
         set_time(cur_tm->tm_hour, cur_tm->tm_min, cur_tm->tm_sec);
-        cur_tm = localtime(&cur_time);
         set_date(cur_tm->tm_year + 1900, cur_tm->tm_mon + 1, cur_tm->tm_mday);
 #else
         rt_device_control(rt_device_find("rtc"), RT_DEVICE_CTRL_RTC_SET_TIME, &cur_time);


### PR DESCRIPTION
这个bug之前已经解决，但是论坛中给出了更好的解决方案。
https://club.rt-thread.org/ask/article/2806.html