### PR TITLE
修正iperf的日志输出

### DIFF
--- a/iperf/iperf.c
+++ b/iperf/iperf.c
@@ -506,7 +506,7 @@ int iperf(int argc, char **argv)
                 }
             }
 
-            tid = rt_thread_create(tid_name, function, RT_NULL, 2048, 20, 100);
+            tid = rt_thread_create(tid_name, function, RT_NULL, IPERF_THREAD_STACK_SIZE, 20, 100);
             if (tid) rt_thread_startup(tid);
         }
     }

--- a/iperf/iperf.c
+++ b/iperf/iperf.c
@@ -163,7 +163,7 @@ static void iperf_udp_server(void *thread_param)
             data = sentlen * RT_TICK_PER_SECOND / 125 / (tick2 - tick1);
             integer = data/1000;
             decimal = data%1000;
-            LOG_I("%s: %d.%03d0 Mbps! lost:%d total:%d\n", IPERF_GET_THREAD_NAME(tid), integer, decimal, lost, total);
+            LOG_I("%s: %d.%03d0 Mbps! lost:%d total:%d", IPERF_GET_THREAD_NAME(tid), integer, decimal, lost, total);
         }
     }
     rt_free(buffer);
@@ -389,7 +389,7 @@ void iperf_usage(void)
     rt_kprintf("  -h           print this message and quit\n");
     rt_kprintf("  --stop       stop iperf program\n");
     rt_kprintf("  -u           testing UDP protocol\n");
-    rt_kprintf("  -m <time>    the number of multi-threaded ");
+    rt_kprintf("  -m <time>    the number of multi-threaded\n");
     return;
 }
 


### PR DESCRIPTION
LOG_I后面有多余换行

rt_kprintf后缺少换行